### PR TITLE
[USD-114] feat : 관리자만 순서 변경 가능하도록 수정

### DIFF
--- a/src/components/playlist/playlistList.tsx
+++ b/src/components/playlist/playlistList.tsx
@@ -34,6 +34,7 @@ const PlaylistList = ({
         patchPlaylistPriority,
         playlistCode: playlistCode!,
         openSuccessToast,
+        isAdmin,
     });
 
     React.useEffect(() => {

--- a/src/hooks/playlist/useSortablePlaylist.ts
+++ b/src/hooks/playlist/useSortablePlaylist.ts
@@ -9,6 +9,7 @@ export function useSortablePlaylist({
   patchPlaylistPriority,
   playlistCode,
   openSuccessToast,
+  isAdmin,
 }: {
   videoList: Video[];
   patchPlaylistPriority: (
@@ -16,6 +17,7 @@ export function useSortablePlaylist({
   ) => Promise<PatchPlaylistPriorityResponse>;
   playlistCode: string;
   openSuccessToast: (msg: string) => void;
+  isAdmin: boolean;
 }) {
   const [localVideoList, setLocalVideoList] = useState<Video[]>(videoList);
 
@@ -25,6 +27,10 @@ export function useSortablePlaylist({
 
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
+      if (!isAdmin) {
+        openSuccessToast('관리자만 순서를 변경할 수 있습니다.');
+        return;
+      }
       const { active, over } = event;
       if (!over || active.id === over.id) return;
 
@@ -47,7 +53,7 @@ export function useSortablePlaylist({
         openSuccessToast('순서 변경에 실패했습니다.');
       }
     },
-    [localVideoList, videoList, patchPlaylistPriority, playlistCode, openSuccessToast],
+    [localVideoList, videoList, patchPlaylistPriority, playlistCode, openSuccessToast, isAdmin],
   );
 
   return [localVideoList, handleDragEnd, setLocalVideoList] as const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 플레이리스트 순서 변경 기능이 관리자에게만 허용되도록 제한되었습니다. 관리자가 아닌 사용자가 순서를 변경하려고 하면 "관리자만 순서를 변경할 수 있습니다."라는 안내 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->