### PR TITLE
[USD-116] fix : event stop propagation 적용

### DIFF
--- a/src/components/playlist/sortableItem.tsx
+++ b/src/components/playlist/sortableItem.tsx
@@ -66,10 +66,11 @@ const SortableItem = ({
                     <div className="relative w-6 h-6 overflow-hidden flex items-center">
                         <IconDelete
                             className={`
-                absolute top-0 left-0
-                ${isDeleteMode ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'}
-              `}
-                            onClick={(e) => handleVideoDelete(e, video)}
+                                absolute top-0 left-0
+                                ${isDeleteMode ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'}
+                            `}
+                            style={{ zIndex: 2, cursor: 'pointer', pointerEvents: 'auto' }}
+                            onClick={e => handleVideoDelete(e, video)}
                         />
                         <span
                             {...listeners}
@@ -82,13 +83,15 @@ const SortableItem = ({
                                 position: 'relative',
                                 cursor: 'grab',
                                 touchAction: 'none',
+                                zIndex: 1,
+                                pointerEvents: isDeleteMode ? 'none' : 'auto',
                             }}
                         >
                             <IconHamburgerDisabled
                                 className={`
-                  absolute top-0 left-0
-                  ${isDeleteMode ? 'translate-x-full opacity-0' : 'translate-x-0 opacity-100'}
-                `}
+                                    absolute top-0 left-0
+                                    ${isDeleteMode ? 'translate-x-full opacity-0' : 'translate-x-0 opacity-100'}
+                                `}
                                 color={hamburgerColor}
                                 onMouseDown={() => setIsHamburgerActive(true)}
                                 onMouseUp={() => setIsHamburgerActive(false)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 삭제 아이콘과 드래그 핸들의 시각적 계층 및 상호작용 방식을 개선하여 삭제 모드에서 더 명확한 조작이 가능하도록 스타일을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->